### PR TITLE
#Version 1.1.1.0

### DIFF
--- a/PackageUpdateInfo/PackageUpdateInfo.psd1
+++ b/PackageUpdateInfo/PackageUpdateInfo.psd1
@@ -3,7 +3,7 @@
     ModuleToProcess = 'PackageUpdateInfo.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.1.0.0'
+    ModuleVersion = '1.1.1.0'
 
     # ID used to uniquely identify this module
     GUID = '1f216c97-d110-4d88-bc30-ec850757a256'

--- a/PackageUpdateInfo/PackageUpdateInfo.psm1
+++ b/PackageUpdateInfo/PackageUpdateInfo.psm1
@@ -1,5 +1,5 @@
 $script:ModuleRoot = $PSScriptRoot
-$script:ModuleVersion = "1.1.0.0" #(Import-PowerShellDataFile -Path "$($script:ModuleRoot)\PackageUpdateInfo.psd1").ModuleVersion
+$script:ModuleVersion = "1.1.1.0" #(Import-PowerShellDataFile -Path "$($script:ModuleRoot)\PackageUpdateInfo.psd1").ModuleVersion
 
 #region Helper function
 function Import-ModuleFile {

--- a/PackageUpdateInfo/changelog.md
+++ b/PackageUpdateInfo/changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+# 1.1.1.0
+- Fix: Command Get-PackageUpdateInfo
+    - Fix Issure #11 - error on command, when more than 63 modules are installed. The command Find-Module only accept a maximum number of 63 strings in Name command. Workarround with a fearch-each loop arround this one
+
 # 1.1.0.0
 - New: command Get-PackageUpdateInfo
     - Possibility to push ToastNotification for update infos with BurnToast module by specifing '-ShowToastNotification' switch

--- a/PackageUpdateInfo/functions/Get-PackageUpdateInfo.ps1
+++ b/PackageUpdateInfo/functions/Get-PackageUpdateInfo.ps1
@@ -121,11 +121,13 @@
 
             # Get available modules from online repositories
             Write-Verbose "Get available modules from online repositories"
-            $findModuleParams = @{
-                Name = $modulesLocal.Name
+            $modulesOnline = foreach ($moduleLocalName in $modulesLocal.Name) {
+                $findModuleParams = @{
+                    Name = $moduleLocalName
+                }
+                if ($Repository) { $findModuleParams.Add("Repository", $Repository) }
+                Find-Module @findModuleParams
             }
-            if ($Repository) { $findModuleParams.Add("Repository", $Repository) }
-            $modulesOnline = Find-Module @findModuleParams
 
             # Compare the version and create output
             Write-Verbose "Compare the version and create output"


### PR DESCRIPTION
# 1.1.1.0
- Fix: Command Get-PackageUpdateInfo
    - Fix Issure #11 - error on command, when more than 63 modules are installed. The command Find-Module only accept a maximum number of 63 strings in Name command. Workarround with a fearch-each loop arround this one