### PR TITLE
Version 1.2.1.0

### DIFF
--- a/PackageUpdateInfo/PackageUpdateInfo.psd1
+++ b/PackageUpdateInfo/PackageUpdateInfo.psd1
@@ -3,7 +3,7 @@
     ModuleToProcess = 'PackageUpdateInfo.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.2.0.0'
+    ModuleVersion = '1.2.1.0'
 
     # ID used to uniquely identify this module
     GUID = '1f216c97-d110-4d88-bc30-ec850757a256'

--- a/PackageUpdateInfo/PackageUpdateInfo.psm1
+++ b/PackageUpdateInfo/PackageUpdateInfo.psm1
@@ -1,5 +1,5 @@
 $script:ModuleRoot = $PSScriptRoot
-$script:ModuleVersion = "1.2.0.0" #(Import-PowerShellDataFile -Path "$($script:ModuleRoot)\PackageUpdateInfo.psd1").ModuleVersion
+$script:ModuleVersion = "1.2.1.0" #(Import-PowerShellDataFile -Path "$($script:ModuleRoot)\PackageUpdateInfo.psd1").ModuleVersion
 
 #region Helper function
 function Import-ModuleFile {

--- a/PackageUpdateInfo/changelog.md
+++ b/PackageUpdateInfo/changelog.md
@@ -1,4 +1,10 @@
 # Changelog
+# 1.2.1.0
+- Fix: Ugly error messages, if no configuration file existis due to fresh system installation.
+    - Implementented check and warning messages on this behaviour
+    - Add init routine in module loading, if no default config file is present
+- Upd: Try to supress verbose messesages on module up-to-dateness checking in *Get-PackageUpdateInfo*
+
 # 1.2.0.0
 - New: Enabling CORE and cross-platform compatibility
     - Doing code refactoring to bring PackageUpdateInfo into PowerShell version 6 & 7 (CORE)

--- a/PackageUpdateInfo/functions/Get-PackageUpdateInfo.ps1
+++ b/PackageUpdateInfo/functions/Get-PackageUpdateInfo.ps1
@@ -150,8 +150,10 @@
             # Get available modules from online repositories
             Write-Verbose "Get available modules from online repositories"
             $modulesOnline = foreach ($moduleLocalName in $modulesLocal.Name) {
-                $findModuleParams = @{ }
-                $findModuleParams["Name"] = $moduleLocalName
+                $findModuleParams = @{
+                    "Name" = $moduleLocalName
+                    "Verbose" = $false
+                }
                 if ($Repository) { $findModuleParams["Repository"] = $Repository }
                 Find-Module @findModuleParams
             }

--- a/PackageUpdateInfo/functions/Get-PackageUpdateSetting.ps1
+++ b/PackageUpdateInfo/functions/Get-PackageUpdateSetting.ps1
@@ -34,7 +34,12 @@
 
     process {
         # read settings file
-        $configuration = Get-Content -Path $Path | ConvertFrom-Json
+        try {
+            $configuration = Get-Content -Path $Path -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            Write-Warning -Message "Module configuration file not found! ($($Path))"
+            Write-Warning -Message "Please check the path or initialize configuration by using 'Set-PackageUpdateSetting -Reset'"
+        }
 
         # Initialize setting object and fill in values
         $output = New-Object -TypeName PackageUpdate.Configuration

--- a/PackageUpdateInfo/functions/Get-PackageUpdateSetting.ps1
+++ b/PackageUpdateInfo/functions/Get-PackageUpdateSetting.ps1
@@ -39,6 +39,7 @@
         } catch {
             Write-Warning -Message "Module configuration file not found! ($($Path))"
             Write-Warning -Message "Please check the path or initialize configuration by using 'Set-PackageUpdateSetting -Reset'"
+            throw
         }
 
         # Initialize setting object and fill in values

--- a/PackageUpdateInfo/internal/scripts/postimport.ps1
+++ b/PackageUpdateInfo/internal/scripts/postimport.ps1
@@ -18,3 +18,8 @@ if (Test-Path -Path $script:ModuleTempPath) {
 } else {
     New-Item -Path $script:ModuleTempPath -ItemType Directory -Force | Out-Null
 }
+
+if (-not (Test-Path -Path $script:ModuleSettingPath)) {
+    Write-Verbose -Message "Going to initialize default settings for module PackageUpdateInfo"
+    Set-PackageUpdateSetting -Reset -Path $script:ModuleSettingPath
+}

--- a/PackageUpdateInfo/internal/scripts/preimport.ps1
+++ b/PackageUpdateInfo/internal/scripts/preimport.ps1
@@ -8,7 +8,7 @@ $optionalModule = @{
 }
 $script:EnableToastNotification = $true
 
-$moduleToLoad = Get-Module -Name $optionalModule.ModuleName -ListAvailable | Where-Object { $_.Version -ge [version]$optionalModule.ModuleVersion } | Sort-Object -Property Version | Select-Object -Last 1
+$moduleToLoad = Get-Module -Name $optionalModule.ModuleName -ListAvailable -Verbose:$false | Where-Object { $_.Version -ge [version]$optionalModule.ModuleVersion } | Sort-Object -Property Version | Select-Object -Last 1
 if ($moduleToLoad) {
     try {
         $moduleToLoad | Import-Module -ErrorAction Stop


### PR DESCRIPTION
# 1.2.1.0
- Fix: Ugly error messages, if no configuration file existis due to fresh system installation.
    - Implementented check and warning messages on this behaviour
    - Add init routine in module loading, if no default config file is present
- Upd: Try to supress verbose messesages on module up-to-dateness checking in *Get-PackageUpdateInfo*