### PR TITLE
Version 1.2.3.0

### DIFF
--- a/PackageUpdateInfo/PackageUpdateInfo.psd1
+++ b/PackageUpdateInfo/PackageUpdateInfo.psd1
@@ -3,7 +3,7 @@
     RootModule = 'PackageUpdateInfo.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.2.2.0'
+    ModuleVersion = '1.2.3.0'
 
     # ID used to uniquely identify this module
     GUID = '1f216c97-d110-4d88-bc30-ec850757a256'

--- a/PackageUpdateInfo/changelog.md
+++ b/PackageUpdateInfo/changelog.md
@@ -1,4 +1,10 @@
 # Changelog
+# 1.2.3.0
+- Fix: Issure #26 - Problem on running PSEdition core & desktop in parallel
+    - Export/Import commands now writes version specific files by default (e.g. PackageUpdateInfo_Desktop_5.xml)
+- Fix: Issue #25 - Export-PackageUpdateInfo -PassThru
+    - fix output issue and date conversion bug
+
 # 1.2.2.0
 - Upd: Add-PackageUpdateRule
     - Parameter PassThru now actually works as intended.

--- a/PackageUpdateInfo/functions/Export-PackageUpdateInfo.ps1
+++ b/PackageUpdateInfo/functions/Export-PackageUpdateInfo.ps1
@@ -14,8 +14,8 @@
         Please specify a file as path.
 
         Default path value is:
-        Linux:   "$HOME/.local/share/powershell/PackageUpdateInfo/PackageUpdateInfo.xml")
-        Windows: "$HOME\AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo.xml")
+        Linux:   "$HOME/.local/share/powershell/PackageUpdateInfo/PackageUpdateInfo_$($PSEdition)_$($PSVersionTable.PSVersion.Major).xml")
+        Windows: "$HOME\AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo_$($PSEdition)_$($PSVersionTable.PSVersion.Major).xml")
 
     .PARAMETER OutputFormat
         The output format for the data
@@ -86,11 +86,11 @@
 
     begin {
         # Set path variable to default value, when not specified
-        if(-not $path) {
-            if($IsLinux) {
-                $path = (Join-Path $HOME ".local/share/powershell/PackageUpdateInfo/PackageUpdateInfo.xml")
+        if (-not $path) {
+            if ($IsLinux) {
+                $path = (Join-Path $HOME ".local/share/powershell/PackageUpdateInfo/PackageUpdateInfo_$($PSEdition)_$($PSVersionTable.PSVersion.Major).xml")
             } else {
-                $path = (Join-Path $HOME "AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo.xml")
+                $path = (Join-Path $HOME "AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo_$($PSEdition)_$($PSVersionTable.PSVersion.Major).xml")
             }
         }
 
@@ -108,9 +108,8 @@
                 $outputPath = New-Item -ItemType File -Path $Path -ErrorAction Stop
                 $outputPath = Resolve-Path -Path $outputPath
             }
-        }
-        # If directory is specified as path
-        elseif (Test-Path -Path $Path -PathType Container) {
+        } elseif (Test-Path -Path $Path -PathType Container) {
+            # If directory is specified as path
             Write-Error -Message "Specified Path is a directory. Please specify an file." -ErrorAction Stop
         } else {
             Write-Error -Message "Specified Path is an invalid directory. Please specify an valid file as output path." -ErrorAction Stop
@@ -137,7 +136,7 @@
                     IconUri          = $object.IconUri
                     ReleaseNotes     = $object.ReleaseNotes
                     Author           = $object.Author
-                    PublishedDate    = $object.PublishedDate
+                    PublishedDate    = ($object.PublishedDate | Get-Date -Format "yyyy-MM-dd HH:mm:ss")
                     Description      = $object.Description
                 }
                 if ($IncludeTimeStamp) {
@@ -148,8 +147,6 @@
         } else {
             $output += $InputObject
         }
-
-        if ($PassThru) { [PackageUpdate.Info]$InputObject }
     }
 
     end {
@@ -174,9 +171,14 @@
                     $Exportdata | Export-Clixml -Path $outputPath.Path -Encoding $Encoding
                 }
             }
+
+            if ($PassThru) {
+                $output | ForEach-Object { [PackageUpdate.Info]$_ }
+            }
         } else {
             Write-Verbose -Message "No data were processed, nothing to output."
             "" | Out-File $outputPath.Path -Encoding $Encoding
         }
+
     }
 }

--- a/PackageUpdateInfo/functions/Import-PackageUpdateInfo.ps1
+++ b/PackageUpdateInfo/functions/Import-PackageUpdateInfo.ps1
@@ -11,8 +11,8 @@
         Please specify a file as path.
 
         Default path value is:
-        Linux:   "$HOME/.local/share/powershell/PackageUpdateInfo/PackageUpdateInfo.xml")
-        Windows: "$HOME\AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo.xml")
+        Linux:   "$HOME/.local/share/powershell/PackageUpdateInfo/PackageUpdateInfo_$($PSEdition)_$($PSVersionTable.PSVersion.Major).xml")
+        Windows: "$HOME\AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo_$($PSEdition)_$($PSVersionTable.PSVersion.Major).xml")
 
     .PARAMETER ShowToastNotification
         This switch invokes nice Windows-Toast-Notifications with release note information on modules with update needed.
@@ -33,7 +33,7 @@
     .EXAMPLE
         PS C:\> Import-PackageUpdateInfo
 
-        Try to import the default file "$HOME\AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo.xml"
+        Try to import the default file "$HOME\AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo_$($PSEdition)_$($PSVersionTable.PSVersion.Major).xml"
     #>
     [CmdletBinding( SupportsShouldProcess = $true,
         ConfirmImpact = 'Low')]
@@ -67,9 +67,9 @@
         # Set path variable to default value, when not specified
         if(-not $path) {
             if($IsLinux) {
-                $path = (Join-Path $HOME ".local/share/powershell/PackageUpdateInfo/PackageUpdateInfo.xml")
+                $path = (Join-Path $HOME ".local/share/powershell/PackageUpdateInfo/PackageUpdateInfo_$($PSEdition)_$($PSVersionTable.PSVersion.Major).xml")
             } else {
-                $path = (Join-Path $HOME "AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo.xml")
+                $path = (Join-Path $HOME "AppData\Local\Microsoft\Windows\PowerShell\PackageUpdateInfo_$($PSEdition)_$($PSVersionTable.PSVersion.Major).xml")
             }
         }
     }
@@ -90,6 +90,7 @@
                 }
 
                 foreach ($record in $records) {
+                    $_date = $record.PublishedDate | Get-Date
                     $hash = [ordered]@{
                         Name             = $record.Name
                         Repository       = $record.Repository
@@ -101,7 +102,7 @@
                         IconUri          = $record.IconUri
                         ReleaseNotes     = $record.ReleaseNotes
                         Author           = $record.Author
-                        PublishedDate    = $record.PublishedDate
+                        PublishedDate    = $_date
                         Description      = $record.Description
                     }
                     $PackageUpdateInfo = [PackageUpdate.Info]$hash

--- a/PackageUpdateInfo/internal/functions/Get-PackageUpdateInfo/Test-UpdateIsNeeded.ps1
+++ b/PackageUpdateInfo/internal/functions/Get-PackageUpdateInfo/Test-UpdateIsNeeded.ps1
@@ -26,10 +26,6 @@
         $moduleOnline
     )
 
-    <#
-    $ModuleLocal = (Get-Module Pester -ListAvailable | select -First 1 )
-    $moduleOnline = (Find-Module -Name Pester)
-    #>
     $versionDiff = Get-VersionDifference -LowerVersion $ModuleLocal.Version -HigherVersion $moduleOnline.Version
     $name = $ModuleLocal.Name
 

--- a/PackageUpdateInfo/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/PackageUpdateInfo/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -4,10 +4,14 @@ Param (
     $SkipTest,
 
     [string[]]
-    $CommandPath = @("$global:testroot\..\functions", "$global:testroot\..\internal\functions")
+    $CommandPath
 )
 
 if ($SkipTest) { return }
+
+if(-not $CommandPath) {
+    [string[]]$CommandPath = @("$global:testroot\..\functions", "$global:testroot\..\internal\functions")
+}
 
 $global:__pester_data.ScriptAnalyzer = New-Object System.Collections.ArrayList
 

--- a/build/azure_pipeline-validate.yml
+++ b/build/azure_pipeline-validate.yml
@@ -1,5 +1,5 @@
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-latest'
 
 # Continuous integration only on branch Development
 trigger:


### PR DESCRIPTION
# Changelog v1.2.3.0
- Fix: Issure #26 - Problem on running PSEdition core & desktop in parallel
    - Export/Import commands now writes version specific files by default (e.g. PackageUpdateInfo_Desktop_5.xml)
- Fix: Issue #25 - Export-PackageUpdateInfo -PassThru
    - fix output issue and date conversion bug