### PR TITLE
Release PackageUpdateInfo version 1.2.4.0

### DIFF
--- a/PackageUpdateInfo/PackageUpdateInfo.psd1
+++ b/PackageUpdateInfo/PackageUpdateInfo.psd1
@@ -3,7 +3,7 @@
     RootModule = 'PackageUpdateInfo.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.2.3.0'
+    ModuleVersion = '1.2.4.0'
 
     # ID used to uniquely identify this module
     GUID = '1f216c97-d110-4d88-bc30-ec850757a256'

--- a/PackageUpdateInfo/changelog.md
+++ b/PackageUpdateInfo/changelog.md
@@ -1,6 +1,9 @@
 # Changelog
+# 1.2.4.0
+- Fix: Issue [#24](https://github.com/AndiBellstedt/PackageUpdateInfo/issues/24) - Module version number 1.9 is higher than 1.10
+    - The online gallery probably delivers version information not as a 'version' type, but as a string.
 # 1.2.3.0
-- Fix: Issure #26 - Problem on running PSEdition core & desktop in parallel
+- Fix: Issure [#24](https://github.com/AndiBellstedt/PackageUpdateInfo/issues/24) - Problem on running PSEdition core & desktop in parallel
     - Export/Import commands now writes version specific files by default (e.g. PackageUpdateInfo_Desktop_5.xml)
 - Fix: Issue #25 - Export-PackageUpdateInfo -PassThru
     - fix output issue and date conversion bug

--- a/PackageUpdateInfo/functions/Get-PackageUpdateInfo.ps1
+++ b/PackageUpdateInfo/functions/Get-PackageUpdateInfo.ps1
@@ -163,11 +163,11 @@
             foreach ($moduleOnline in $modulesOnline) {
                 $moduleLocal = $modulesLocal | Where-Object Name -like $moduleOnline.Name
 
-                if ($moduleOnline.version -gt $moduleLocal.version) {
+                if ([version]($moduleOnline.version) -gt [version]($moduleLocal.version)) {
                     Write-Verbose "Update available for module '$($moduleOnline.Name)': local v$($moduleLocal.version) --> v$($moduleOnline.version) online"
                     $UpdateAvailable = Test-UpdateIsNeeded -ModuleLocal $moduleLocal -ModuleOnline $moduleOnline
                     #$UpdateAvailable = $true
-                } elseif ($moduleOnline.version -lt $moduleLocal.version) {
+                } elseif ([version]($moduleOnline.version) -lt [version]($moduleLocal.version)) {
                     Write-Warning "Local version for module '$($moduleOnline.Name)' is higher than online version: local v$($moduleLocal.version) <-- v$($moduleOnline.version) online"
                     $UpdateAvailable = $false
                 } else {


### PR DESCRIPTION
# 1.2.4.0
- Fix: Issue [#24](https://github.com/AndiBellstedt/PackageUpdateInfo/issues/24) - Module version number 1.9 is higher than 1.10
    - The online gallery probably delivers version information not as a 'version' type, but as a string.