### PR TITLE
Release PackageUpdateInfo version 1.2.5.0

### DIFF
--- a/PackageUpdateInfo/PackageUpdateInfo.psd1
+++ b/PackageUpdateInfo/PackageUpdateInfo.psd1
@@ -3,7 +3,7 @@
     RootModule = 'PackageUpdateInfo.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.2.4.0'
+    ModuleVersion = '1.2.5.0'
 
     # ID used to uniquely identify this module
     GUID = '1f216c97-d110-4d88-bc30-ec850757a256'

--- a/PackageUpdateInfo/changelog.md
+++ b/PackageUpdateInfo/changelog.md
@@ -1,7 +1,18 @@
 # Changelog
+# 1.2.5.0
+- Fix: Issue [#33](https://github.com/AndiBellstedt/PackageUpdateInfo/issues/33) - Get-PackageUpdateInfo ignores ExcludeModuleFromChecking\
+    - Optimize filtering for module checking against galleries
+- Upd:
+    - Command Get-PackageUpdateInfo\
+        Optimize filtering to fit requirement on issue [#33](https://github.com/AndiBellstedt/PackageUpdateInfo/issues/33)
+    - Command Set-PackageUpdateSetting\
+        Add examples in the documentation\
+        ! Please read the examples befor putting anything on the exclusion list
+
 # 1.2.4.0
 - Fix: Issue [#24](https://github.com/AndiBellstedt/PackageUpdateInfo/issues/24) - Module version number 1.9 is higher than 1.10
     - The online gallery probably delivers version information not as a 'version' type, but as a string.
+
 # 1.2.3.0
 - Fix: Issure [#24](https://github.com/AndiBellstedt/PackageUpdateInfo/issues/24) - Problem on running PSEdition core & desktop in parallel
     - Export/Import commands now writes version specific files by default (e.g. PackageUpdateInfo_Desktop_5.xml)

--- a/PackageUpdateInfo/functions/Set-PackageUpdateSetting.ps1
+++ b/PackageUpdateInfo/functions/Set-PackageUpdateSetting.ps1
@@ -89,6 +89,30 @@
         If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
     .EXAMPLE
+        PS C:\> Set-PackageUpdateSetting -ExcludeModuleFromChecking "MyLocalOnlyModule"
+
+        Put the module "MyLocalOnlyModule" on the exclude list for update checking.
+        By design, this should be considered only for modules not available in a online gallery.
+        This capability is designed to avoid unnecessary update checks, for modules not existing in a online gallery.
+
+        You'll not get any update information for module 'MyLocalOnlyModule' anymore!
+
+        If you have worries/issues on performance, due to a large number of modules installed, you better follow the practice to put the 'checking mechansim' in you PSProfile as a job routine every time you start a shell.
+        Doing so is described in the 'practical-usage' on the github project page:
+        https://github.com/AndiBellstedt/PackageUpdateInfo#practical-usage
+
+    .EXAMPLE
+        PS C:\> Set-PackageUpdateSetting -ExcludeModuleFromChecking "Az.*"
+
+        Put all Az. modules on the exclude list for update checking.
+        This should be considered as a bad practice, because you'll not get any update information for all Az. modules anymore.
+        (and they might change quite often)
+
+        If you have worries/issues on performance, due to a large number of modules installed, you better follow the practice to put the 'checking mechansim' in you PSProfile as a job routine every time you start a shell.
+        Doing so is described in the 'practical-usage' on the github project page:
+        https://github.com/AndiBellstedt/PackageUpdateInfo#practical-usage
+
+    .EXAMPLE
         PS C:\> Set-PackageUpdateSetting -ExcludeModuleFromChecking @("") -IncludeModuleForChecking "*" -ReportChangeOnMajor $true -ReportChangeOnMinor $true -ReportChangeOnBuild $true -ReportChangeOnRevision $true -UpdateCheckInterval "01:00:00"
 
         Reset module to it'S default behaviour

--- a/PackageUpdateInfo/internal/functions/Get-PackageUpdateInfo/Test-UpdateIsNeeded.ps1
+++ b/PackageUpdateInfo/internal/functions/Get-PackageUpdateInfo/Test-UpdateIsNeeded.ps1
@@ -34,6 +34,7 @@
     foreach ($rule in $rules) {
         Write-Verbose -Message "Working on rule $($rule.Id)"
         $stop = $false
+
         # check for exclude and abort further processing for rule
         foreach ($exclude in $rule.ExcludeModuleFromChecking) {
             if ($name -like $exclude) {


### PR DESCRIPTION
# 1.2.5.0
- Fix: Issue [#33](https://github.com/AndiBellstedt/PackageUpdateInfo/issues/33) - Get-PackageUpdateInfo ignores ExcludeModuleFromChecking\
    - Optimize filtering for module checking against galleries
- Upd:
    - Command Get-PackageUpdateInfo\
        Optimize filtering to fit requirement on issue [#33](https://github.com/AndiBellstedt/PackageUpdateInfo/issues/33)
    - Command Set-PackageUpdateSetting\
        Add examples in the documentation\
        ! Please read the examples befor putting anything on the exclusion list
