### PR TITLE
fix: Update Invoke-WebRequest to use basic parsing (KB5074596)

### DIFF
--- a/PackageUpdateInfo/internal/functions/Get-PackageUpdateInfo/Show-ToastNotification.ps1
+++ b/PackageUpdateInfo/internal/functions/Get-PackageUpdateInfo/Show-ToastNotification.ps1
@@ -48,7 +48,7 @@
             if (Test-Path -Path $iconPath) { Remove-Item -Path $iconPath -Force -ErrorAction:SilentlyContinue }
 
             try {
-                Invoke-WebRequest -Uri $PackageUpdateInfo.IconUri -OutFile $iconPath -SkipCertificateCheck -SkipHeaderValidation -ErrorAction Stop
+                Invoke-WebRequest -Uri $PackageUpdateInfo.IconUri -OutFile $iconPath -SkipCertificateCheck -SkipHeaderValidation -UseBasicParsing -ErrorAction Stop
                 $toastLogo = $iconPath
             } catch {
                 Write-Verbose -Message "Warning! Unable to get icon from '$($PackageUpdateInfo.IconUri)' for module '$($PackageUpdateInfo.Name)'"


### PR DESCRIPTION
CVE-2025-54100

Updated the Invoke-WebRequest command in Show-ToastNotification to include the -UseBasicParsing parameter because of KB5074596 (CVE-2025-54100)